### PR TITLE
feat/auth: 로그인, 회원가입, 로그아웃 및 세션 관리 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,8 @@ dependencies {
     testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.4'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -1,8 +1,20 @@
+# CREATE TABLE users (
+#     user_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+#     username VARCHAR(50) NOT NULL UNIQUE,
+#     password VARCHAR(100) NOT NULL,
+#     nickname VARCHAR(50) NOT NULL,
+#     role VARCHAR(20) DEFAULT 'USER',
+#     enabled BOOLEAN DEFAULT TRUE
+# );
+
 CREATE TABLE users (
-    user_id BIGINT AUTO_INCREMENT PRIMARY KEY,
-    username VARCHAR(50) NOT NULL UNIQUE,
-    password VARCHAR(100) NOT NULL,
-    nickname VARCHAR(50) NOT NULL,
-    role VARCHAR(20) DEFAULT 'USER',
-    enabled BOOLEAN DEFAULT TRUE
+   user_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+   username VARCHAR(50) NOT NULL UNIQUE,
+   password VARCHAR(100) NOT NULL,
+   nickname VARCHAR(50) NOT NULL,
+   role VARCHAR(20) DEFAULT 'USER',
+   enabled BOOLEAN DEFAULT TRUE,   -- 계정 활성화 여부
+   points INT DEFAULT 0,           -- 유저 포인트 (기본값 0)
+   report_count INT DEFAULT 0,     -- 리포트 카운트 (기본값 0)
+   is_banned BOOLEAN DEFAULT FALSE -- 유저가 밴된 상태인지 여부
 );

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -1,0 +1,8 @@
+CREATE TABLE users (
+    user_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    username VARCHAR(50) NOT NULL UNIQUE,
+    password VARCHAR(100) NOT NULL,
+    nickname VARCHAR(50) NOT NULL,
+    role VARCHAR(20) DEFAULT 'USER',
+    enabled BOOLEAN DEFAULT TRUE
+);

--- a/src/main/java/org/example/llmquestionboard/config/SecurityConfig.java
+++ b/src/main/java/org/example/llmquestionboard/config/SecurityConfig.java
@@ -31,7 +31,10 @@ public class SecurityConfig {
                         .deleteCookies("JSESSIONID") // 쿠키 삭제
                         .permitAll()
                 )
-                .userDetailsService(customUserDetailService);
+                .userDetailsService(customUserDetailService)
+                .sessionManagement(session -> session
+                        .sessionFixation().newSession())
+        ;
         return http.build();
     }
 

--- a/src/main/java/org/example/llmquestionboard/config/SecurityConfig.java
+++ b/src/main/java/org/example/llmquestionboard/config/SecurityConfig.java
@@ -1,0 +1,22 @@
+package org.example.llmquestionboard.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
+}

--- a/src/main/java/org/example/llmquestionboard/config/SecurityConfig.java
+++ b/src/main/java/org/example/llmquestionboard/config/SecurityConfig.java
@@ -21,12 +21,16 @@ public class SecurityConfig {
                 .formLogin(form -> form
                         .loginPage("/login")
                         .failureUrl("/login?error=true")  // 로그인 실패 시 리디렉션할 URL
-                        .defaultSuccessUrl("/")
+                        .defaultSuccessUrl("/", false)
                         .permitAll()
                 )
                 .logout(logout -> logout
-                        .logoutSuccessUrl("/")
-                        .permitAll())
+                        .logoutUrl("/logout")
+                        .logoutSuccessUrl("/") // 로그아웃 후 이동할 경로
+                        .invalidateHttpSession(true) // 세션 무효화
+                        .deleteCookies("JSESSIONID") // 쿠키 삭제
+                        .permitAll()
+                )
                 .userDetailsService(customUserDetailService);
         return http.build();
     }

--- a/src/main/java/org/example/llmquestionboard/config/SecurityConfig.java
+++ b/src/main/java/org/example/llmquestionboard/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package org.example.llmquestionboard.config;
 
+import org.example.llmquestionboard.service.CustomUserDetailService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -11,7 +12,22 @@ import org.springframework.security.web.SecurityFilterChain;
 public class SecurityConfig {
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http, CustomUserDetailService customUserDetailService) throws Exception {
+        http
+                .authorizeHttpRequests(authz -> authz
+                        .requestMatchers("/signup", "/login", "/check-**").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .formLogin(form -> form
+                        .loginPage("/login")
+                        .failureUrl("/login?error=true")  // 로그인 실패 시 리디렉션할 URL
+                        .defaultSuccessUrl("/")
+                        .permitAll()
+                )
+                .logout(logout -> logout
+                        .logoutSuccessUrl("/")
+                        .permitAll())
+                .userDetailsService(customUserDetailService);
         return http.build();
     }
 

--- a/src/main/java/org/example/llmquestionboard/controller/AuthController.java
+++ b/src/main/java/org/example/llmquestionboard/controller/AuthController.java
@@ -63,13 +63,11 @@ public class AuthController {
     }
 
     @GetMapping("/login")
-    public String login() {
+    public String login(@RequestParam(value = "error", required = false) String error, Model model) {
+        if (error != null) {
+            model.addAttribute("errorMessage", "아이디나 비밀번호가 잘못되었습니다.");
+        }
         return "auth/login";
     }
 
-    @PostMapping("/login")
-    public String login(@RequestParam String username, @RequestParam String password) {
-
-        return "redirect;/";
-    }
 }

--- a/src/main/java/org/example/llmquestionboard/controller/AuthController.java
+++ b/src/main/java/org/example/llmquestionboard/controller/AuthController.java
@@ -1,11 +1,13 @@
 package org.example.llmquestionboard.controller;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.example.llmquestionboard.model.dto.SignupDTO;
 import org.example.llmquestionboard.service.AuthService;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.*;
 
 @Controller
 @RequiredArgsConstructor
@@ -14,16 +16,50 @@ public class AuthController {
     private final AuthService authService;
 
     @GetMapping("/signup")
-    public String signup() {
+    public String signup(Model model) {
+        model.addAttribute("signupDTO", new SignupDTO("", "", "", ""));
         return "auth/signup";
     }
 
     @PostMapping("/signup")
-    public String signup(@RequestParam String username,
-                         @RequestParam String nickname,
-                         @RequestParam String password) {
-        authService.signup(username, nickname, password);
+    public String signup(@Valid SignupDTO signupDTO, BindingResult bindingResult) {
+//        authService.signup(username, nickname, password);
+
+        if (authService.isDuplicateUsername(signupDTO.username())) {
+          bindingResult.rejectValue("username", "username.exists", "이미 사용 중인 아이디입니다.");
+          return "auth/signup";
+        }
+
+        if (authService.isNicknameTaken(signupDTO.nickname())) {
+            bindingResult.rejectValue("nickname", "nickname.exists", "이미 사용 중인 닉네임입니다.");
+            return "auth/signup";
+        }
+
+        if(!signupDTO.password().equals(signupDTO.confirmPassword())) {
+            bindingResult.rejectValue("confirmPassword", "password.mismatch", "비밀번호가 일치하지 않습니다.");
+            return "auth/signup";
+        }
+
+        if (bindingResult.hasErrors()) {
+            return "auth/signup";
+        }
+
+        authService.signup(signupDTO);
         return "redirect:/login";
+    }
+
+    // 유저네임 중복 AJAX 체크
+    @ResponseBody
+    @GetMapping("/check-username")
+    public boolean checkUsername(@RequestParam String username) {
+        return authService.isDuplicateUsername(username);
+    }
+
+    // 닉네임 중복 AJAX 체크
+    @ResponseBody
+    @GetMapping("/check-nickname")
+    public boolean checkNickname(@RequestParam String nickname) {
+        return authService.isNicknameTaken(nickname);
     }
 
     @GetMapping("/login")

--- a/src/main/java/org/example/llmquestionboard/controller/AuthController.java
+++ b/src/main/java/org/example/llmquestionboard/controller/AuthController.java
@@ -1,0 +1,39 @@
+package org.example.llmquestionboard.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.example.llmquestionboard.service.AuthService;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Controller
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @GetMapping("/signup")
+    public String signup() {
+        return "auth/signup";
+    }
+
+    @PostMapping("/signup")
+    public String signup(@RequestParam String username,
+                         @RequestParam String nickname,
+                         @RequestParam String password) {
+        authService.signup(username, nickname, password);
+        return "redirect:/login";
+    }
+
+    @GetMapping("/login")
+    public String login() {
+        return "auth/login";
+    }
+
+    @PostMapping("/login")
+    public String login(@RequestParam String username, @RequestParam String password) {
+
+        return "redirect;/";
+    }
+}

--- a/src/main/java/org/example/llmquestionboard/model/domain/Users.java
+++ b/src/main/java/org/example/llmquestionboard/model/domain/Users.java
@@ -6,9 +6,12 @@ public record Users(
         String password,
         String nickname, // 별명
         String role,
-        Boolean enabled
+        Boolean enabled,
+        int points,
+        int reportCount,
+        boolean isBanned
 ) {
     public static Users joinUsers(String username, String password, String nickname) {
-        return new Users(0L, username, password, nickname, "USER", true);
+        return new Users(0L, username, password, nickname, "USER", true, 0, 0, false);
     }
 }

--- a/src/main/java/org/example/llmquestionboard/model/domain/Users.java
+++ b/src/main/java/org/example/llmquestionboard/model/domain/Users.java
@@ -1,0 +1,14 @@
+package org.example.llmquestionboard.model.domain;
+
+public record Users(
+        Long userId, // 식별자
+        String username, // 로그인용
+        String password,
+        String nickname, // 별명
+        String role,
+        Boolean enabled
+) {
+    public static Users joinUsers(String username, String password, String nickname) {
+        return new Users(0L, username, password, nickname, "USER", true);
+    }
+}

--- a/src/main/java/org/example/llmquestionboard/model/dto/SignupDTO.java
+++ b/src/main/java/org/example/llmquestionboard/model/dto/SignupDTO.java
@@ -1,0 +1,22 @@
+package org.example.llmquestionboard.model.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record SignupDTO(
+
+        @NotBlank(message = "아이디는 필수입니다.")
+        @Size(min = 4, max = 20, message = "아이디는 4~20자여야 합니다.")
+        String username,
+
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
+        String password,
+
+        @NotBlank(message = "비밀번호 확인은 필수입니다.")
+        String confirmPassword,
+
+        @NotBlank(message = "닉네임은 필수입니다.")
+        String nickname
+) {
+}

--- a/src/main/java/org/example/llmquestionboard/model/mapper/UsersMapper.java
+++ b/src/main/java/org/example/llmquestionboard/model/mapper/UsersMapper.java
@@ -1,0 +1,12 @@
+package org.example.llmquestionboard.model.mapper;
+
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Mapper;
+import org.example.llmquestionboard.model.domain.Users;
+
+@Mapper
+public interface UsersMapper {
+
+    @Insert("INSERT INTO users (username, password, nickname) VALUES (#{username}, #{password}, #{nickname})")
+    void insertUser(Users users);
+}

--- a/src/main/java/org/example/llmquestionboard/model/mapper/UsersMapper.java
+++ b/src/main/java/org/example/llmquestionboard/model/mapper/UsersMapper.java
@@ -16,4 +16,7 @@ public interface UsersMapper {
 
     @Select("SELECT COUNT(*) FROM users WHERE nickname = #{nickname}")
     int countByNickname(String nickname);
+
+    @Select("SELECT * FROM users WHERE username = #{username}")
+    Users findByUsername(String username);
 }

--- a/src/main/java/org/example/llmquestionboard/model/mapper/UsersMapper.java
+++ b/src/main/java/org/example/llmquestionboard/model/mapper/UsersMapper.java
@@ -2,6 +2,7 @@ package org.example.llmquestionboard.model.mapper;
 
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Select;
 import org.example.llmquestionboard.model.domain.Users;
 
 @Mapper
@@ -9,4 +10,10 @@ public interface UsersMapper {
 
     @Insert("INSERT INTO users (username, password, nickname) VALUES (#{username}, #{password}, #{nickname})")
     void insertUser(Users users);
+
+    @Select("SELECT COUNT(*) FROM users WHERE username = #{username}")
+    int countByUsername(String username);
+
+    @Select("SELECT COUNT(*) FROM users WHERE nickname = #{nickname}")
+    int countByNickname(String nickname);
 }

--- a/src/main/java/org/example/llmquestionboard/model/security/CustomUserDetails.java
+++ b/src/main/java/org/example/llmquestionboard/model/security/CustomUserDetails.java
@@ -1,0 +1,19 @@
+package org.example.llmquestionboard.model.security;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+
+import java.util.Collection;
+
+public class CustomUserDetails extends User {
+    private final String nickname;  // 추가된 닉네임 필드
+
+    public CustomUserDetails(String username, String password, Collection<? extends GrantedAuthority> authorities, String nickname) {
+        super(username, password, authorities);
+        this.nickname = nickname;
+    }
+
+    public String getNickname() {
+        return nickname;
+    }
+}

--- a/src/main/java/org/example/llmquestionboard/service/AuthService.java
+++ b/src/main/java/org/example/llmquestionboard/service/AuthService.java
@@ -2,6 +2,7 @@ package org.example.llmquestionboard.service;
 
 import lombok.RequiredArgsConstructor;
 import org.example.llmquestionboard.model.domain.Users;
+import org.example.llmquestionboard.model.dto.SignupDTO;
 import org.example.llmquestionboard.model.mapper.UsersMapper;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -13,9 +14,24 @@ public class AuthService {
     private final UsersMapper usersMapper;
     private final PasswordEncoder passwordEncoder;
 
-    public void signup(String username, String nickname, String password) {
-        String encodedPassword = passwordEncoder.encode(password);
-        Users joinUser = Users.joinUsers(username, encodedPassword, nickname);
+//    public void signup(String username, String nickname, String password) {
+//        String encodedPassword = passwordEncoder.encode(password);
+//        Users joinUser = Users.joinUsers(username, encodedPassword, nickname);
+//        usersMapper.insertUser(joinUser);
+//    }
+
+    public void signup(SignupDTO signupDTO) {
+        String encodedPassword = passwordEncoder.encode(signupDTO.password());
+        Users joinUser = Users.joinUsers(signupDTO.username(), encodedPassword, signupDTO.nickname());
         usersMapper.insertUser(joinUser);
+    }
+
+    public boolean isDuplicateUsername(String username) {
+        return usersMapper.countByUsername(username) > 0;
+
+    }
+
+    public boolean isNicknameTaken(String nickname) {
+        return usersMapper.countByNickname(nickname) > 0;
     }
 }

--- a/src/main/java/org/example/llmquestionboard/service/AuthService.java
+++ b/src/main/java/org/example/llmquestionboard/service/AuthService.java
@@ -1,0 +1,21 @@
+package org.example.llmquestionboard.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.llmquestionboard.model.domain.Users;
+import org.example.llmquestionboard.model.mapper.UsersMapper;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final UsersMapper usersMapper;
+    private final PasswordEncoder passwordEncoder;
+
+    public void signup(String username, String nickname, String password) {
+        String encodedPassword = passwordEncoder.encode(password);
+        Users joinUser = Users.joinUsers(username, encodedPassword, nickname);
+        usersMapper.insertUser(joinUser);
+    }
+}

--- a/src/main/java/org/example/llmquestionboard/service/CustomUserDetailService.java
+++ b/src/main/java/org/example/llmquestionboard/service/CustomUserDetailService.java
@@ -1,0 +1,34 @@
+package org.example.llmquestionboard.service;
+
+import org.example.llmquestionboard.model.domain.Users;
+import org.example.llmquestionboard.model.mapper.UsersMapper;
+import org.example.llmquestionboard.model.security.CustomUserDetails;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+
+@Service
+public class CustomUserDetailService implements UserDetailsService {
+    private final UsersMapper usersMapper;
+
+    public CustomUserDetailService(UsersMapper usersMapper) {
+        this.usersMapper = usersMapper;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        Users user = usersMapper.findByUsername(username);
+        if (user == null) {
+            throw new UsernameNotFoundException("사용자를 찾을 수 없습니다");
+        }
+        return new CustomUserDetails(
+                user.username(), user.password(),
+                Collections.singleton(new SimpleGrantedAuthority("ROLE_%s".formatted(user.role()))),
+                user.nickname()
+        );
+    }
+}

--- a/src/main/resources/templates/auth/login.html
+++ b/src/main/resources/templates/auth/login.html
@@ -1,0 +1,30 @@
+<!-- templates/auth/login.html -->
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      th:replace="~{layout/layout :: layout(~{::body})}">
+<body>
+<div th:fragment="content">
+    <div class="row justify-content-center mt-5">
+        <div class="col-md-6">
+            <h2 class="mb-4 text-center">로그인</h2>
+            <form th:action="@{/login}" method="post">
+                <div class="mb-3">
+                    <label for="username" class="form-label">아이디</label>
+                    <input type="text" class="form-control" id="username" name="username" required />
+                </div>
+                <div class="mb-3">
+                    <label for="password" class="form-label">비밀번호</label>
+                    <input type="password" class="form-control" id="password" name="password" required />
+                </div>
+                <div class="d-grid">
+                    <button type="submit" class="btn btn-primary">로그인</button>
+                </div>
+                <div class="text-end mt-2">
+                    <a href="/signup">회원가입</a>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/auth/login.html
+++ b/src/main/resources/templates/auth/login.html
@@ -16,9 +16,16 @@
                     <label for="password" class="form-label">비밀번호</label>
                     <input type="password" class="form-control" id="password" name="password" required />
                 </div>
+
+                <!-- 에러 메시지 출력 -->
+                <div th:if="${errorMessage}" style="color: red;">
+                    <p th:text="${errorMessage}"></p>
+                </div>
+
                 <div class="d-grid">
                     <button type="submit" class="btn btn-primary">로그인</button>
                 </div>
+
                 <div class="text-end mt-2">
                     <a href="/signup">회원가입</a>
                 </div>
@@ -26,5 +33,22 @@
         </div>
     </div>
 </div>
+
+<script>
+    document.getElementById('username').addEventListener('focus', function() {
+        const errorDiv = document.querySelector('[th\\:if="${errorMessage}"]');
+        if (errorDiv) {
+            errorDiv.style.display = 'none';  // 포커스 시 에러 메시지 숨기기
+        }
+    });
+
+    document.getElementById('password').addEventListener('focus', function() {
+        const errorDiv = document.querySelector('[th\\:if="${errorMessage}"]');
+        if (errorDiv) {
+            errorDiv.style.display = 'none';  // 포커스 시 에러 메시지 숨기기
+        }
+    });
+</script>
+
 </body>
 </html>

--- a/src/main/resources/templates/auth/signup.html
+++ b/src/main/resources/templates/auth/signup.html
@@ -7,29 +7,145 @@
     <div class="row justify-content-center mt-5">
         <div class="col-md-6">
             <h2 class="mb-4 text-center">회원가입</h2>
-            <form th:action="@{/signup}" method="post">
+            <form th:action="@{/signup}" method="post" th:object="${signupDTO}" onsubmit="return validatePasswords()">
                 <div class="mb-3">
                     <label for="username" class="form-label">아이디</label>
-                    <input type="text" class="form-control" id="username" name="username" required />
+                    <input type="text" class="form-control" id="username" th:field="*{username}" required />
+                    <p id="username-check"></p>
+<!--                    <span th:errors="*{username}"></span>-->
+                    <p th:if="${#fields.hasErrors('username')}" th:errors="*{username}" style="color: red" id="usernameError"></p>
                 </div>
                 <div class="mb-3">
                     <label for="nickname" class="form-label">닉네임</label>
-                    <input type="text" class="form-control" id="nickname" name="nickname" required />
+                    <input type="text" class="form-control" id="nickname" th:field="*{nickname}" required />
+                    <p id="nickname-check"></p>
+                    <p th:if="${#fields.hasErrors('nickname')}" th:errors="*{nickname}" style="color: red" id="nicknameError"></p>
                 </div>
                 <div class="mb-3">
                     <label for="password" class="form-label">비밀번호</label>
-                    <input type="password" class="form-control" id="password" name="password" required />
+                    <input type="password" class="form-control" id="password" th:field="*{password}" required />
+                    <p th:if="${#fields.hasErrors('password')}" th:errors="*{password}" style="color: red" id="passwordError"></p>
+
                 </div>
-<!--                <div class="mb-3">-->
-<!--                    <label for="confirmPassword" class="form-label">비밀번호 확인</label>-->
-<!--                    <input type="password" class="form-control" id="confirmPassword" name="confirmPassword" required />-->
-<!--                </div>-->
+                <div class="mb-3">
+                    <label for="confirmPassword" class="form-label">비밀번호 확인</label>
+                    <input type="password" class="form-control" id="confirmPassword" th:field="*{confirmPassword}" required />
+                    <p th:if="${#fields.hasErrors('confirmPassword')}" th:errors="*{confirmPassword}" id="confirmPasswordError"></p>
+                    <div id="confirmError" style="color:red;"></div>
+                </div>
                 <div class="d-grid">
-                    <button type="submit" class="btn btn-success">회원가입</button>
+                    <button type="submit" class="btn btn-success" id="signupBtn" disabled>회원가입</button>
                 </div>
             </form>
         </div>
     </div>
 </div>
+
+<script>
+    function hideErrorOnInput(inputId, errorId) {
+        const input = document.getElementById(inputId);
+        const error = document.getElementById(errorId);
+
+        if (input && error) {
+            input.addEventListener("input", () => error.style.display = "none");
+        }
+    }
+
+    document.addEventListener("DOMContentLoaded", () => {
+        hideErrorOnInput("username", "usernameError");
+        hideErrorOnInput("nickname", "nicknameError");
+        hideErrorOnInput("password", "passwordError");
+        hideErrorOnInput("confirmPassword", "confirmPasswordError");
+        // 필요한 만큼 추가
+    });
+
+
+    let isUsernameAvailable = false;
+    let isNicknameAvailable = false;
+
+    function toggleSubmitButton() {
+        const submitBtn = document.getElementById('signupBtn');
+        if (isUsernameAvailable && isNicknameAvailable) {
+            submitBtn.disabled = false;
+        } else {
+            submitBtn.disabled = true;
+        }
+    }
+
+    // AJAX - 아이디 중복 검사
+    document.getElementById('username').addEventListener('blur', function () {
+        const username = this.value;
+        fetch(`/check-username?username=${encodeURIComponent(username)}`)
+            .then(response => response.json())
+            .then(isTaken => {
+                const result = document.getElementById('username-check');
+                if (isTaken) {
+                    result.textContent = '이미 사용 중인 이름입니다.';
+                    result.style.color = 'red';
+                    isUsernameAvailable = false;
+                } else {
+                    result.textContent = '사용 가능한 이름입니다.';
+                    result.style.color = 'green';
+                    isUsernameAvailable = true;
+                }
+                toggleSubmitButton();
+            });
+    });
+
+    // AJAX - 닉네임 중복 검사
+    document.getElementById('nickname').addEventListener('blur', function () {
+        const nickname = this.value;
+        fetch(`/check-nickname?nickname=${encodeURIComponent(nickname)}`)
+            .then(response => response.json())
+            .then(isTaken => {
+                const result = document.getElementById('nickname-check');
+                if (isTaken) {
+                    result.textContent = '이미 사용 중인 닉네임입니다.';
+                    result.style.color = 'red';
+                    isNicknameAvailable = false;
+                } else {
+                    result.textContent = '사용 가능한 닉네임입니다.';
+                    result.style.color = 'green';
+                    isNicknameAvailable = true;
+                }
+                toggleSubmitButton();
+            });
+    });
+
+    // 사용자가 값 바꾸면 초기화
+    document.getElementById('username').addEventListener('input', () => {
+        isUsernameAvailable = false;
+        toggleSubmitButton();
+    });
+    document.getElementById('nickname').addEventListener('input', () => {
+        isNicknameAvailable = false;
+        toggleSubmitButton();
+    });
+
+
+    function validatePasswords() {
+        const password = document.getElementById('password').value;
+        const confirm = document.getElementById('confirmPassword').value;
+        const errorDiv = document.getElementById('confirmError');
+
+        if (!isUsernameAvailable) {
+            alert("아이디 중복 확인이 필요합니다.");
+            return false;
+        }
+
+        if (!isNicknameAvailable) {
+            alert("닉네임 중복 확인이 필요합니다.");
+            return false;
+        }
+
+        if (password !== confirm) {
+            errorDiv.textContent = '비밀번호가 일치하지 않습니다.';
+            return false;
+        }
+
+        errorDiv.textContent = '';
+        return true;
+    }
+</script>
 </body>
 </html>

--- a/src/main/resources/templates/auth/signup.html
+++ b/src/main/resources/templates/auth/signup.html
@@ -1,0 +1,35 @@
+<!-- templates/auth/signup.html -->
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      th:replace="~{layout/layout :: layout(~{::body})}">
+<body>
+<div th:fragment="content">
+    <div class="row justify-content-center mt-5">
+        <div class="col-md-6">
+            <h2 class="mb-4 text-center">회원가입</h2>
+            <form th:action="@{/signup}" method="post">
+                <div class="mb-3">
+                    <label for="username" class="form-label">아이디</label>
+                    <input type="text" class="form-control" id="username" name="username" required />
+                </div>
+                <div class="mb-3">
+                    <label for="nickname" class="form-label">닉네임</label>
+                    <input type="text" class="form-control" id="nickname" name="nickname" required />
+                </div>
+                <div class="mb-3">
+                    <label for="password" class="form-label">비밀번호</label>
+                    <input type="password" class="form-control" id="password" name="password" required />
+                </div>
+<!--                <div class="mb-3">-->
+<!--                    <label for="confirmPassword" class="form-label">비밀번호 확인</label>-->
+<!--                    <input type="password" class="form-control" id="confirmPassword" name="confirmPassword" required />-->
+<!--                </div>-->
+                <div class="d-grid">
+                    <button type="submit" class="btn btn-success">회원가입</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/layout/header.html
+++ b/src/main/resources/templates/layout/header.html
@@ -4,8 +4,24 @@
             <a class="navbar-brand" href="/">AI 질문 게시판</a>
             <div class="collapse navbar-collapse">
                 <ul class="navbar-nav ms-auto">
-                    <li class="nav-item"><a class="nav-link" href="/login">로그인</a></li>
-                    <li class="nav-item"><a class="nav-link" href="/signup">회원가입</a></li>
+                    <!-- 로그인된 상태에서만 로그인 이름과 로그아웃 표시 -->
+                    <li class="nav-item" th:if="${#authentication != null and #authentication.name != 'anonymousUser'}">
+                        <a class="nav-link" href="#">안녕하세요! <span th:text="${#authentication.principal.nickname}"></span> 님</a>
+                    </li>
+                    <li class="nav-item" th:if="${#authentication != null and #authentication.name != 'anonymousUser'}">
+<!--                        <a class="nav-link" href="/logout">로그아웃</a>-->
+                        <form th:action="@{/logout}" method="post" style="display: inline;">
+                            <button type="submit" class="btn btn-link">로그아웃</button>
+                        </form>
+                    </li>
+
+                    <!-- 로그인되지 않은 상태에서만 로그인, 회원가입 표시 -->
+                    <li class="nav-item" th:if="${#authentication == null or #authentication.name == 'anonymousUser'}">
+                        <a class="nav-link" href="/login">로그인</a>
+                    </li>
+                    <li class="nav-item" th:if="${#authentication == null or #authentication.name == 'anonymousUser'}">
+                        <a class="nav-link" href="/signup">회원가입</a>
+                    </li>
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
## 📌 작업 개요
- 로그인, 회원가입, 로그아웃 기능을 구현하였으며, 세션 관리 및 리디렉션 처리를 추가했습니다.
- 로그인 실패 후 에러 메시지 출력 및 로그인 성공 시 리디렉션 처리를 추가하였습니다.
- 로그인 시 세션 고정 보호를 추가하여 보안을 강화하였습니다.
- Users 테이블에 필요한 컬럼을 추가하여 유저 정보를 확장할 수 있게 했습니다.

## ✅ 상세 내용
- **회원가입 기능**: 사용자 아이디와 비밀번호, 닉네임을 이용한 회원가입 기능 구현
- **로그인 기능**: 사용자 인증을 위한 로그인 구현, 로그인 실패 시 에러 메시지 출력
- **로그아웃 기능**: 사용자가 로그아웃할 수 있도록 구현
- **세션 관리**: 로그인 후 세션을 관리하고, 세션 고정 보호를 추가하여 보안을 강화
- **Users 테이블 컬럼 수정**: 유저 정보에 포인트, 리포트 카운트, 밴 여부 등 추가 컬럼을 추가
- **기타**: 로그인 실패 시 로그인 페이지에 에러 메시지 출력 처리