### PR TITLE
fix: 유저아이디 UUID 적용 및 회원가입 예외 처리 

### DIFF
--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -8,7 +8,7 @@
 # );
 
 CREATE TABLE users (
-   user_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+   user_id VARCHAR(36) PRIMARY KEY,
    username VARCHAR(50) NOT NULL UNIQUE,
    password VARCHAR(100) NOT NULL,
    nickname VARCHAR(50) NOT NULL,

--- a/src/main/java/org/example/llmquestionboard/controller/AuthController.java
+++ b/src/main/java/org/example/llmquestionboard/controller/AuthController.java
@@ -22,7 +22,7 @@ public class AuthController {
     }
 
     @PostMapping("/signup")
-    public String signup(@Valid SignupDTO signupDTO, BindingResult bindingResult) {
+    public String signup(@Valid SignupDTO signupDTO, BindingResult bindingResult, Model model) {
 //        authService.signup(username, nickname, password);
 
         if (authService.isDuplicateUsername(signupDTO.username())) {
@@ -44,8 +44,13 @@ public class AuthController {
             return "auth/signup";
         }
 
-        authService.signup(signupDTO);
-        return "redirect:/login";
+        try {
+            authService.signup(signupDTO);
+            return "redirect:/login"; // 가입 성공 시 로그인 페이지로 리디렉션
+        } catch (Exception e) {
+            model.addAttribute("errorMessage", e.getMessage()); // 실패한 경우 에러 메시지 전달
+            return "auth/signup"; // 가입 페이지로 다시 리디렉션
+        }
     }
 
     // 유저네임 중복 AJAX 체크

--- a/src/main/java/org/example/llmquestionboard/model/domain/Users.java
+++ b/src/main/java/org/example/llmquestionboard/model/domain/Users.java
@@ -1,7 +1,9 @@
 package org.example.llmquestionboard.model.domain;
 
+import java.util.UUID;
+
 public record Users(
-        Long userId, // 식별자
+        String userId, // 식별자
         String username, // 로그인용
         String password,
         String nickname, // 별명
@@ -12,6 +14,6 @@ public record Users(
         boolean isBanned
 ) {
     public static Users joinUsers(String username, String password, String nickname) {
-        return new Users(0L, username, password, nickname, "USER", true, 0, 0, false);
+        return new Users(UUID.randomUUID().toString(), username, password, nickname, "USER", true, 0, 0, false);
     }
 }

--- a/src/main/java/org/example/llmquestionboard/model/mapper/UsersMapper.java
+++ b/src/main/java/org/example/llmquestionboard/model/mapper/UsersMapper.java
@@ -8,7 +8,7 @@ import org.example.llmquestionboard.model.domain.Users;
 @Mapper
 public interface UsersMapper {
 
-    @Insert("INSERT INTO users (username, password, nickname) VALUES (#{username}, #{password}, #{nickname})")
+    @Insert("INSERT INTO users (user_id, username, password, nickname) VALUES (#{userId}, #{username}, #{password}, #{nickname})")
     void insertUser(Users users);
 
     @Select("SELECT COUNT(*) FROM users WHERE username = #{username}")

--- a/src/main/java/org/example/llmquestionboard/model/security/CustomUserDetails.java
+++ b/src/main/java/org/example/llmquestionboard/model/security/CustomUserDetails.java
@@ -6,14 +6,20 @@ import org.springframework.security.core.userdetails.User;
 import java.util.Collection;
 
 public class CustomUserDetails extends User {
+    private final String userId;
     private final String nickname;  // 추가된 닉네임 필드
 
-    public CustomUserDetails(String username, String password, Collection<? extends GrantedAuthority> authorities, String nickname) {
+    public CustomUserDetails(String username, String password, Collection<? extends GrantedAuthority> authorities, String nickname, String userId) {
         super(username, password, authorities);
         this.nickname = nickname;
+        this.userId = userId;
     }
 
     public String getNickname() {
         return nickname;
+    }
+
+    public String getUserId() {
+        return userId;
     }
 }

--- a/src/main/java/org/example/llmquestionboard/service/AuthService.java
+++ b/src/main/java/org/example/llmquestionboard/service/AuthService.java
@@ -6,6 +6,7 @@ import org.example.llmquestionboard.model.dto.SignupDTO;
 import org.example.llmquestionboard.model.mapper.UsersMapper;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -20,10 +21,15 @@ public class AuthService {
 //        usersMapper.insertUser(joinUser);
 //    }
 
+    @Transactional
     public void signup(SignupDTO signupDTO) {
         String encodedPassword = passwordEncoder.encode(signupDTO.password());
         Users joinUser = Users.joinUsers(signupDTO.username(), encodedPassword, signupDTO.nickname());
-        usersMapper.insertUser(joinUser);
+        try {
+            usersMapper.insertUser(joinUser);
+        } catch (Exception e) {
+            throw new RuntimeException("가입 실패: 데이터베이스 오류");
+        }
     }
 
     public boolean isDuplicateUsername(String username) {

--- a/src/main/java/org/example/llmquestionboard/service/CustomUserDetailService.java
+++ b/src/main/java/org/example/llmquestionboard/service/CustomUserDetailService.java
@@ -28,7 +28,8 @@ public class CustomUserDetailService implements UserDetailsService {
         return new CustomUserDetails(
                 user.username(), user.password(),
                 Collections.singleton(new SimpleGrantedAuthority("ROLE_%s".formatted(user.role()))),
-                user.nickname()
+                user.nickname(),
+                user.userId()
         );
     }
 }

--- a/src/main/resources/templates/auth/signup.html
+++ b/src/main/resources/templates/auth/signup.html
@@ -33,6 +33,11 @@
                     <p th:if="${#fields.hasErrors('confirmPassword')}" th:errors="*{confirmPassword}" id="confirmPasswordError"></p>
                     <div id="confirmError" style="color:red;"></div>
                 </div>
+
+                <!-- 에러 메시지 출력 -->
+                <div th:if="${errorMessage}" class="alert alert-danger">
+                    <p th:text="${errorMessage}"></p>
+                </div>
                 <div class="d-grid">
                     <button type="submit" class="btn btn-success" id="signupBtn" disabled>회원가입</button>
                 </div>


### PR DESCRIPTION
## ✅ 상세 내용
- 기존 AUTO_INCREMENT 방식의 user_id를 UUID(String)로 변경
- 회원가입 중 예외 발생 시, 로그인 페이지로 리디렉션되는 문제 수정
- 트랜잭션 롤백 처리 및 적절한 예외 메시지 반환

## 🛠 변경 이유
UUID 방식으로 사용자 ID를 식별할 경우, 보안 및 유추 방지에 유리함  